### PR TITLE
Add bitcoin core v26.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,32 +8,14 @@ jobs:
     strategy:
       matrix:
         version:
+          - '26'
+          - '26/alpine'
           - '25'
           - '25/alpine'
           - '24'
           - '24/alpine'
           - '23'
           - '23/alpine'
-          - '22'
-          - '22/alpine'
-          - '0.21'
-          - '0.21/alpine'
-          - '0.20'
-          - '0.20/alpine'
-          - '0.19'
-          - '0.19/alpine'
-          - '0.18'
-          - '0.18/alpine'
-          - '0.17'
-          - '0.17/alpine'
-          - '0.16'
-          - '0.16/alpine'
-          - '0.13'
-          - '0.13/alpine'
-          - '0.12'
-          - '0.12/alpine'
-          - '0.11'
-          - '0.11/alpine'
       fail-fast: false
     steps:
       - name: Set up Docker Buildx

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -1,0 +1,69 @@
+FROM debian:bookworm-slim
+
+ARG UID=101
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN groupadd --gid ${GID} bitcoin \
+  && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
+  && apt-get update -y \
+  && apt-get install -y curl gnupg gosu \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG TARGETPLATFORM
+ENV BITCOIN_VERSION=26.0
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN set -ex \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
+  && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
+  && for key in \
+  101598DC823C1B5F9A6624ABA5E0907A0380E6C3 \
+  F2CFC4ABD0B99D837EEBB7D09B79B45691DB4173 \
+  152812300785C96444D3334D17565732E08E5E41 \
+  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
+  C060A6635913D98A3587D7DB1C2491FFEB0EF770 \
+  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
+  F19F5FF2B0589EC341220045BA03F4DBE0C63FB4 \
+  F4FC70F07310028424EFC20A8E4256593F177720 \
+  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
+  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
+  9DEAE0DC7063249FB05474681E4AED62986CD25D \
+  6A8F9C266528E25AEB1D7731C2371D91CB716EA7 \
+  28E72909F1717FE9607754F8A7BEB2621678D37D \
+  616516B8EB6ED02882FC4A7A8ADCB558C4F33D65 \
+  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
+  ; do \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
+  && gpg --verify SHA256SUMS.asc SHA256SUMS \
+  && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
+  && tar -xzf *.tar.gz -C /opt \
+  && rm *.tar.gz *.asc \
+  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
+
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18443 18444 38333 38332
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -1,0 +1,144 @@
+# Build stage for BerkeleyDB
+FROM alpine as berkeleydb
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add build-base
+RUN apk --no-cache add libressl
+
+ENV BERKELEYDB_VERSION=db-4.8.30.NC
+ENV BERKELEYDB_PREFIX=/opt/${BERKELEYDB_VERSION}
+
+RUN wget https://download.oracle.com/berkeley-db/${BERKELEYDB_VERSION}.tar.gz
+RUN tar -xzf *.tar.gz
+RUN sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i ${BERKELEYDB_VERSION}/dbinc/atomic.h
+RUN mkdir -p ${BERKELEYDB_PREFIX}
+
+WORKDIR /${BERKELEYDB_VERSION}/build_unix
+
+RUN ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${BERKELEYDB_PREFIX} --build=aarch64-unknown-linux-gnu
+RUN make -j4
+RUN make install
+RUN rm -rf ${BERKELEYDB_PREFIX}/docs
+
+# Build stage for Bitcoin Core
+FROM alpine as bitcoin-core
+
+COPY --from=berkeleydb /opt /opt
+
+ENV GNUPGHOME=/tmp/gnupg
+
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add autoconf
+RUN apk --no-cache add automake
+RUN apk --no-cache add boost-dev
+RUN apk --no-cache add build-base
+RUN apk --no-cache add chrpath
+RUN apk --no-cache add file
+RUN apk --no-cache add gnupg
+RUN apk --no-cache add libevent-dev
+RUN apk --no-cache add libressl
+RUN apk --no-cache add libtool
+RUN apk --no-cache add linux-headers
+RUN apk --no-cache add sqlite-dev
+RUN apk --no-cache add zeromq-dev
+RUN mkdir -p ${GNUPGHOME}
+RUN set -ex \
+  && for key in \
+  101598DC823C1B5F9A6624ABA5E0907A0380E6C3 \
+  F2CFC4ABD0B99D837EEBB7D09B79B45691DB4173 \
+  152812300785C96444D3334D17565732E08E5E41 \
+  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
+  C060A6635913D98A3587D7DB1C2491FFEB0EF770 \
+  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
+  F19F5FF2B0589EC341220045BA03F4DBE0C63FB4 \
+  F4FC70F07310028424EFC20A8E4256593F177720 \
+  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
+  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
+  9DEAE0DC7063249FB05474681E4AED62986CD25D \
+  6A8F9C266528E25AEB1D7731C2371D91CB716EA7 \
+  28E72909F1717FE9607754F8A7BEB2621678D37D \
+  616516B8EB6ED02882FC4A7A8ADCB558C4F33D65 \
+  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
+  ; do \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
+  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
+  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done
+
+ENV BITCOIN_VERSION=26.0
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
+RUN wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}.tar.gz
+RUN gpg --verify SHA256SUMS.asc SHA256SUMS
+RUN grep " bitcoin-${BITCOIN_VERSION}.tar.gz\$" SHA256SUMS | sha256sum -c -
+RUN tar -xzf *.tar.gz
+
+WORKDIR /bitcoin-${BITCOIN_VERSION}
+
+RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat/compat.h
+RUN ./autogen.sh
+RUN ./configure LDFLAGS=-L`ls -d /opt/db*`/lib/ CPPFLAGS=-I`ls -d /opt/db*`/include/ \
+  --prefix=${BITCOIN_PREFIX} \
+  --mandir=/usr/share/man \
+  --disable-tests \
+  --disable-bench \
+  --disable-ccache \
+  --with-gui=no \
+  --with-utils \
+  --with-libs \
+  --with-sqlite=yes \
+  --with-daemon
+RUN make -j4
+RUN make install
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-cli
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoin-tx
+RUN strip ${BITCOIN_PREFIX}/bin/bitcoind
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.a
+RUN strip ${BITCOIN_PREFIX}/lib/libbitcoinconsensus.so.0.0.0
+
+# Build stage for compiled artifacts
+FROM alpine
+
+ARG UID=100
+ARG GID=101
+
+LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
+  maintainer.1="Pedro Branco (@pedrobranco)" \
+  maintainer.2="Rui Marinho (@ruimarinho)"
+
+RUN addgroup bitcoin --gid ${GID} --system
+RUN adduser --uid ${UID} --system bitcoin --ingroup bitcoin
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
+RUN apk --no-cache add \
+  boost-filesystem \
+  boost-system \
+  boost-thread \
+  libevent \
+  libzmq \
+  shadow \
+  sqlite-dev \
+  su-exec
+
+ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
+ENV BITCOIN_VERSION=26.0
+ENV BITCOIN_PREFIX=/opt/bitcoin-${BITCOIN_VERSION}
+ENV PATH=${BITCOIN_PREFIX}/bin:$PATH
+
+COPY --from=bitcoin-core /opt /opt
+COPY docker-entrypoint.sh /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 8332 8333 18332 18333 18444
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+RUN bitcoind -version | grep "Bitcoin Core version v${BITCOIN_VERSION}"
+
+CMD ["bitcoind"]

--- a/26/alpine/docker-entrypoint.sh
+++ b/26/alpine/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec su-exec bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/26/docker-entrypoint.sh
+++ b/26/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+if [ -n "${UID+x}" ] && [ "${UID}" != "0" ]; then
+  usermod -u "$UID" bitcoin
+fi
+
+if [ -n "${GID+x}" ] && [ "${GID}" != "0" ]; then
+  groupmod -g "$GID" bitcoin
+fi
+
+echo "$0: assuming uid:gid for bitcoin:bitcoin of $(id -u bitcoin):$(id -g bitcoin)"
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ] || [ "$1" = "bitcoind" ]; then
+  mkdir -p "$BITCOIN_DATA"
+  chmod 700 "$BITCOIN_DATA"
+  # Fix permissions for home dir.
+  chown -R bitcoin:bitcoin "$(getent passwd bitcoin | cut -d: -f6)"
+  # Fix permissions for bitcoin data dir.
+  chown -R bitcoin:bitcoin "$BITCOIN_DATA"
+
+  echo "$0: setting data directory to $BITCOIN_DATA"
+
+  set -- "$@" -datadir="$BITCOIN_DATA"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo
+  exec gosu bitcoin "$@"
+fi
+
+echo
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ A bitcoin-core docker image with support for the following platforms:
 
 ## Tags
 
+- `26.0`, `26` ([26/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/Dockerfile)) [**multi-arch**]
+- `26.0-alpine`, `26-alpine` ([26/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/alpine/Dockerfile))
+
 - `25.0`, `25` ([25/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/Dockerfile)) [**multi-arch**]
 - `25.0-alpine`, `25-alpine` ([25/alpine/Dockerfile](https://github.com/ruimarinho/docker-bitcoin-core/blob/master/25/alpine/Dockerfile))
 


### PR DESCRIPTION
This is mostly copy/paste of the files for 25, with the following manual changes applied to them to fix the build:

Debian based image:
 - bump base image from `bullseye-slim` to `bookworm-slim`
 - Add signing keys `616516B8EB6ED02882FC4A7A8ADCB558C4F33D65` and `ED9BDF7AD6A55E232E84524257FF9BDBCC301009`

Alpine based image:
 - set `GNUPGHOME` environment variable to `/tmp/gnupg` to fix an issue with `gpg --verify` hanging
 - Add signing keys `616516B8EB6ED02882FC4A7A8ADCB558C4F33D65` and `ED9BDF7AD6A55E232E84524257FF9BDBCC301009`

I tested the `linux/amd64` build locally for both base image types.