### PR TITLE
Improve Dockerfile

### DIFF
--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer.0="João Fonseca (@joaopaulofonseca)" \
 RUN groupadd --gid ${GID} bitcoin \
   && useradd --create-home --no-log-init -u ${UID} -g ${GID} bitcoin \
   && apt-get update -y \
-  && apt-get install -y curl gnupg gosu \
+  && apt-get --no-install-recommends -y install jq curl gnupg gosu ca-certificates \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -19,43 +19,25 @@ ENV BITCOIN_VERSION=26.0
 ENV BITCOIN_DATA=/home/bitcoin/.bitcoin
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 
+SHELL ["/bin/bash", "-c"]
 RUN set -ex \
   && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export TARGETPLATFORM=x86_64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export TARGETPLATFORM=aarch64-linux-gnu; fi \
   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then export TARGETPLATFORM=arm-linux-gnueabihf; fi \
-  && for key in \
-  101598DC823C1B5F9A6624ABA5E0907A0380E6C3 \
-  F2CFC4ABD0B99D837EEBB7D09B79B45691DB4173 \
-  152812300785C96444D3334D17565732E08E5E41 \
-  0AD83877C1F0CD1EE9BD660AD7CC770B81FD22A8 \
-  C060A6635913D98A3587D7DB1C2491FFEB0EF770 \
-  CFB16E21C950F67FA95E558F2EEB9F5CC09526C1 \
-  F19F5FF2B0589EC341220045BA03F4DBE0C63FB4 \
-  F4FC70F07310028424EFC20A8E4256593F177720 \
-  D1DBF2C4B96F2DEBF4C16654410108112E7EA81F \
-  287AE4CA1187C68C08B49CB2D11BD4F33F1DB499 \
-  9DEAE0DC7063249FB05474681E4AED62986CD25D \
-  6A8F9C266528E25AEB1D7731C2371D91CB716EA7 \
-  28E72909F1717FE9607754F8A7BEB2621678D37D \
-  616516B8EB6ED02882FC4A7A8ADCB558C4F33D65 \
-  ED9BDF7AD6A55E232E84524257FF9BDBCC301009 \
-  ; do \
-  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-  gpg --batch --keyserver keys.openpgp.org --recv-keys "$key" || \
-  gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-  gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-  gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  && SIGNERS=($(curl -sS "https://api.github.com/repos/bitcoin-core/guix.sigs/contents/${BITCOIN_VERSION}" | jq -r '.[] | select(.type=="dir") | .name' | tr "\n" " ")) \
+  && for name in "${SIGNERS[@]}"; do \
+  curl -sSL "https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/builder-keys/${name}.gpg" | gpg --import - ; \
   done \
   && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz \
   && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS \
   && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc \
   && gpg --verify SHA256SUMS.asc SHA256SUMS \
   && grep " bitcoin-${BITCOIN_VERSION}-${TARGETPLATFORM}.tar.gz" SHA256SUMS | sha256sum -c - \
-  && tar -xzf *.tar.gz -C /opt \
-  && rm *.tar.gz *.asc \
-  && rm -rf /opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt
-
+  && tar -xzf ./*.tar.gz -C /opt \
+  && rm ./*.tar.gz ./*.asc \
+  && rm -rf "/opt/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-qt" \
+  && rm -rf "/opt/bitcoin-${BITCOIN_VERSION}/bin/test_bitcoin"
+  
 COPY docker-entrypoint.sh /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]


### PR DESCRIPTION
The current way how the Dockerfile does the signature checking (by hardcoding the keys) is very error-prone because those keys change every release.

Therefore I implemented an automatic retrieval of the keys from the official ```bitcoin-core/guix.sigs``` repository. So that for every version the correct keys are retrieved.