### PR TITLE
Enable github CI build for bitcoin core v30.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         version:
+          - '30'
+          - '30/alpine'
           - '29.1'
           - '29.1/alpine'
           - '29'


### PR DESCRIPTION
Previously in https://github.com/lightninglabs/docker-bitcoin-core/pull/12 we added the Dockerfiles for Bitcoin Core v30.0. However, builds in CI were not enabled as they do not set the RC vars.

This PR enables the full release (non RC) to be build in CI and pushed to Dockerhub.